### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/muons-io/dock-gen/security/code-scanning/3](https://github.com/muons-io/dock-gen/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Since the workflow involves reading repository contents and publishing a NuGet package, we will set `contents: read` and `packages: write`. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
